### PR TITLE
Improve message about required firewall openings

### DIFF
--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -265,7 +265,7 @@
             this.noClientLabel.Size = new System.Drawing.Size(292, 76);
             this.noClientLabel.TabIndex = 10;
             this.noClientLabel.Text = "Headset not found.\r\n\r\nMake sure the client is launched.\r\nOr check the firewall se" +
-    "ttings (permit UDP/9944).";
+    "ttings (permit UDP/9943 and UDP/9944).";
             this.noClientLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // dataGridView1


### PR DESCRIPTION
According to netstat (and some other observations) only port 9943 is listened during headset discovery.

In case port 9944 is opened in firewall (but 9943 is not opened) the headset isn't discovered, and existing message ("check the firewall settings (permit UDP/9944)") is very misleading.
Hence the idea to include both ports in the message (this PR contains message where both ports are mentioned).